### PR TITLE
Configure Maven Fork Test parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,7 @@
 				<configuration>
 					<argLine>${argLine} -Xmx512m</argLine>
 					<printSummary>true</printSummary>
+					<forkCount>1.5C</forkCount>
 					<!--  <skipTests>false</skipTests>  -->
   				</configuration>
 			</plugin>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
