### PR TITLE
Remove maven-shade-plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Changed
+### Fixed
+- Removed maven-shade-plugin as it broke the phtree dependency. [#25](https://github.com/tzaeschke/tinspin-indexes/issues/25)
 - Added some tests and removed some dead code. [#23](https://github.com/tzaeschke/tinspin-indexes/pull/23)
 
 ## [2.0.0] - 2023-07-25

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 		<dependency>
 			<groupId>ch.ethz.globis.phtree</groupId>
 			<artifactId>phtree</artifactId>
-			<version>[2.6,)</version>
+			<version>[2.8,)</version>
 		</dependency>
 		<dependency>
 			<groupId>org.tinspin</groupId>
@@ -100,22 +100,6 @@
 
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.4.1</version>
-				<executions>
-					<execution>
-						<phase>package</phase>
-						<goals>
-							<goal>shade</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<finalName>${project.groupId}-${project.artifactId}-${project.version}-all</finalName>
-				</configuration>
-			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
@@ -219,19 +203,6 @@
   				</executions>
 			</plugin>
 		</plugins>
-
-		<testResources>
-			<testResource>
-				<directory>${project.basedir}/tst</directory>
-				<excludes>
-			        <exclude>**/*.java</exclude>
-				</excludes>
-			</testResource>
-			<testResource>
-				<!-- Add the default dir when overwriting testResource: -->
- 				<directory>${project.basedir}/src/test/resources</directory>
- 			</testResource>
-    	</testResources>
 	</build>
 
 </project>


### PR DESCRIPTION
It broke the phtree dependency after upgrade to maven-shade-plugin 3.4.1. See #25.

This PR also remove some unnecessary resource copying and updates the phtree dependency to minimum 2.8.0.