### PR TITLE
Removed GPL references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-- Nothing yet
+- Remove erroneour references to GPL 3.0. This library is APL 2.0 only. [#27](https://github.com/tzaeschke/tinspin-indexes/pull/27)
 
 ## [2.0.1] - 2023-08-01
 

--- a/src/test/java/org/tinspin/index/test/util/JmxTools.java
+++ b/src/test/java/org/tinspin/index/test/util/JmxTools.java
@@ -1,22 +1,19 @@
 /*
- * Copyright 2009-2017 Tilmann Zaeschke. All rights reserved.
- * 
- * This file is part of ZooDB.
- * 
- * ZooDB is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- * 
- * ZooDB is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License
- * along with ZooDB.  If not, see <http://www.gnu.org/licenses/>.
- * 
- * See the README and COPYING files for further information. 
+ * Copyright 2009-2023 Tilmann Zaeschke. All rights reserved.
+ *
+ * This file is part of TinSpin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.tinspin.index.test.util;
 


### PR DESCRIPTION
Removed erroneous references to GPL 3.0. This project is completely licensed under Apache Public License 2.0.