### PR TITLE
Fix test cadidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [#29](https://github.com/tzaeschke/tinspin-indexes/pull/29)
 
 ### Fixed
+- Test candidates should counsistently use integers as values.
+  [#31](https://github.com/tzaeschke/tinspin-indexes/pull/31)
 - Remove erroneous references to GPL 3.0. This library is APL 2.0 only. 
   [#27](https://github.com/tzaeschke/tinspin-indexes/pull/27), [#28](https://github.com/tzaeschke/tinspin-indexes/pull/28)
 

--- a/src/test/java/org/tinspin/index/test/util/BoxMapCandidate.java
+++ b/src/test/java/org/tinspin/index/test/util/BoxMapCandidate.java
@@ -24,13 +24,12 @@ import static org.tinspin.index.Index.*;
 
 public class BoxMapCandidate extends Candidate {
 	
-	private final BoxMap<Object> idx;
+	private final BoxMap<Integer> idx;
 	private final int dims;
 	private final int N;
 	private double[] data;
-	private static final Object O = new Object();
-	private BoxIterator<Object> query = null;
-	private BoxIteratorKnn<Object> queryKnn = null;
+	private BoxIterator<Integer> query = null;
+	private BoxIteratorKnn<Integer> queryKnn = null;
 	private final boolean bulkloadSTR;
 
 	public static BoxMapCandidate create(TestStats ts) {
@@ -60,7 +59,7 @@ public class BoxMapCandidate extends Candidate {
 	public BoxMapCandidate(BoxMap<?> ri, TestStats ts) {
 		this.N = ts.cfgNEntries;
 		this.dims = ts.cfgNDims;
-		this.idx = (BoxMap<Object>) ri;
+		this.idx = (BoxMap<Integer>) ri;
 		this.bulkloadSTR = ts.INDEX.equals(TestInstances.IDX.STR);
 	}
 	
@@ -69,7 +68,7 @@ public class BoxMapCandidate extends Candidate {
 	public void load(double[] data, int dims) {
 		this.data = data;
 		if (bulkloadSTR) {
-			RTreeEntry<Object>[] entries = new RTreeEntry[N];
+			RTreeEntry<Integer>[] entries = new RTreeEntry[N];
 			int pos = 0;
 			for (int i = 0; i < N; i++) {
 				double[] lo = new double[dims];
@@ -78,9 +77,9 @@ public class BoxMapCandidate extends Candidate {
 				pos += dims;
 				System.arraycopy(data, pos, hi, 0, dims);
 				pos += dims;
-				entries[i] = RTreeEntry.createBox(lo, hi, O);
+				entries[i] = RTreeEntry.createBox(lo, hi, i);
 			}
-			RTree<Object> rt = (RTree<Object>) idx;
+			RTree<Integer> rt = (RTree<Integer>) idx;
 			rt.load(entries);
 		} else {
 			int pos = 0;
@@ -91,7 +90,7 @@ public class BoxMapCandidate extends Candidate {
 				pos += dims;
 				System.arraycopy(data, pos, hi, 0, dims);
 				pos += dims;
-				idx.insert(lo, hi, O);
+				idx.insert(lo, hi, n);
 			}
 		}
 	}
@@ -170,7 +169,7 @@ public class BoxMapCandidate extends Candidate {
 		double ret = 0;
 		int i = 0;
 		while (queryKnn.hasNext() && i < k) {
-			BoxEntryKnn<Object> e = queryKnn.next();
+			BoxEntryKnn<Integer> e = queryKnn.next();
 			ret += e.dist();
 			i++;
 		}

--- a/src/test/java/org/tinspin/index/test/util/PointMapCandidate.java
+++ b/src/test/java/org/tinspin/index/test/util/PointMapCandidate.java
@@ -28,12 +28,12 @@ import static org.tinspin.index.Index.*;
 
 public class PointMapCandidate extends Candidate {
 	
-	private final PointMap<double[]> idx;
+	private final PointMap<Integer> idx;
 	private final int dims;
 	private final int N;
 	private double[] data;
-	private PointIterator<double[]> it;
-	private PointIteratorKnn<double[]> itKnn;
+	private PointIterator<Integer> it;
+	private PointIteratorKnn<Integer> itKnn;
 	private final boolean bulkloadSTR;
 	private final IndexHandle index;
 
@@ -69,7 +69,7 @@ public class PointMapCandidate extends Candidate {
 	public PointMapCandidate(PointMap<?> pi, TestStats ts) {
 		this.N = ts.cfgNEntries;
 		this.dims = ts.cfgNDims;
-		idx = (PointMap<double[]>) pi;
+		idx = (PointMap<Integer>) pi;
 		this.index = ts.INDEX;
 		this.bulkloadSTR = IDX.STR == this.index;
 	}
@@ -79,15 +79,15 @@ public class PointMapCandidate extends Candidate {
 	public void load(double[] data, int dims) {
 		this.data = data;
 		if (bulkloadSTR) {
-			RTreeEntry<double[]>[] entries = new RTreeEntry[N];
+			RTreeEntry<Integer>[] entries = new RTreeEntry[N];
 			int pos = 0;
 			for (int i = 0; i < N; i++) {
 				double[] buf = new double[dims];
 				System.arraycopy(data, pos, buf, 0, dims);
 				pos += dims;
-				entries[i] = RTreeEntry.createPoint(buf, buf);
+				entries[i] = RTreeEntry.createPoint(buf, i);
 			}
-			PointMapWrapper<double[]> rt = (PointMapWrapper<double[]>) idx;
+			PointMapWrapper<Integer> rt = (PointMapWrapper<Integer>) idx;
 			rt.load(entries);
 		} else {
 			for (int i = 0; i < N; i++) {
@@ -95,7 +95,7 @@ public class PointMapCandidate extends Candidate {
 				for (int d = 0; d < dims; d++) {
 					buf[d] = data[i*dims+d]; 
 				}
-				idx.insert(buf, buf);
+				idx.insert(buf, i);
 			}
 		}
 	}


### PR DESCRIPTION
The test candidates should consistently use `Integer` as value type.
Some use `Object` and others use `double[]`.