### PR TITLE
Add power of 2 for all quadtrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Fixed tree consistency (single-entry leaf after remove)
   - Fixed tree consistency (nValues) -> verify
   - Fixed bug in qt2.contains()
-- Fixed QT2 inconsistency after root resizing after insert(). [#42](https://github.com/tzaeschke/tinspin-indexes/issues/42)
+- Fixed QT2 inconsistency after root resizing after insert(). 
   Essentially, we force all radii and the center of the root to be powers of two.
-  This should immensely reduce precision problems. 
+  This should immensely reduce precision problems.
+  [#42](https://github.com/tzaeschke/tinspin-indexes/issues/42)
 - Removed unnecessary JUnit test console output. [#45](https://github.com/tzaeschke/tinspin-indexes/pull/45)
 
 ## [2.1.3] - 2023-11-19

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Indexes can be created via factories in the interfaces, e.g. `PointMap.Factory.c
 Note:
  - **STR-Trees** are simply R-Trees that are preloaded using the STR algorithm. THis can be done with
    the factory methods `....Factory.createAndLoadStrRTree(...)`.
+ - **Quadtree precision problems**. Many quadtree implementations are vulnerable to precision problem due to repeated 
+   division by 2.0 of radius and subnode centers. Our quadtree implementations avoid this problem by aligning node center
+   coordinates and radius to a power of two. Power of two values are mostly immune to precision problems when dividing by 2.0.
  - `PointArray` and `BoxArray` are simple array based implementations. They scale badly with size, their only use is for verifying correctness of other indexes. 
 
 ## Changelog

--- a/src/main/java/org/tinspin/index/BoxMap.java
+++ b/src/main/java/org/tinspin/index/BoxMap.java
@@ -147,6 +147,7 @@ public interface BoxMap<T> extends Index {
         }
 
         /**
+         * WARNING: Unaligned center and radius can cause precision problems, see README.
          * Create a plain Quadtree.
          * Min/max are used to find a good initial root. They do not need to be exact. If possible, min/max should
          * span an area that is somewhat larger rather than smaller than the actual data.
@@ -157,9 +158,30 @@ public interface BoxMap<T> extends Index {
          * @param max             Estimated maximum of all coordinates.
          * @param <T>             Value type
          * @return New Quadtree
+         * @deprecated Please use {@link #createQuadtree(double[], double[], boolean, int)}
          */
+        @Deprecated
         static <T> BoxMap<T> createQuadtree(int dims, int maxNodeCapacity, double[] min, double[] max) {
             return QuadTreeRKD0.create(dims, maxNodeCapacity, min, max);
+        }
+
+        /**
+         * Create a plain Quadtree.
+         * Min/max are used to find a good initial root. They do not need to be exact. If possible, min/max should
+         * span an area that is somewhat larger rather than smaller than the actual data.
+         * <p>
+         * Center and radius will be aligned with powers of two to avoid precision problems.
+         *
+         * @param min             Estimated minimum of all coordinates.
+         * @param max             Estimated maximum of all coordinates.
+         * @param align           Whether center and radius should be aligned to powers of two. Aligning considerably
+         *                        reduces risk of precision problems. Recommended: "true".
+         * @param maxNodeCapacity Maximum entries in a node before the node is split. The default is 10.
+         * @param <T>             Value type
+         * @return New Quadtree
+         */
+        static <T> BoxMap<T> createQuadtree(double[] min, double[] max, boolean align, int maxNodeCapacity) {
+            return QuadTreeRKD0.create(min, max, align, maxNodeCapacity);
         }
 
         /**
@@ -174,7 +196,8 @@ public interface BoxMap<T> extends Index {
         }
 
         /**
-         * Create a plain Quadtree.
+         * WARNING: Unaligned center and radius can cause precision problems, see README.
+         * Create a Quadtree with hypercube navigation.
          * Min/max are used to find a good initial root. They do not need to be exact. If possible, min/max should
          * span an area that is somewhat larger rather than smaller than the actual data.
          *
@@ -184,9 +207,30 @@ public interface BoxMap<T> extends Index {
          * @param max             Estimated maximum of all coordinates.
          * @param <T>             Value type
          * @return New QuadtreeHC
+         * @deprecated Please use {@link #createQuadtree(double[], double[], boolean, int)}
          */
+        @Deprecated
         static <T> BoxMap<T> createQuadtreeHC(int dims, int maxNodeCapacity, double[] min, double[] max) {
             return QuadTreeRKD.create(dims, maxNodeCapacity, min, max);
+        }
+
+        /**
+         * Create a Quadtree with hypercube navigation.
+         * Min/max are used to find a good initial root. They do not need to be exact. If possible, min/max should
+         * span an area that is somewhat larger rather than smaller than the actual data.
+         * <p>
+         * Center and radius will be aligned with powers of two to avoid precision problems.
+         *
+         * @param min             Estimated minimum of all coordinates.
+         * @param max             Estimated maximum of all coordinates.
+         * @param align           Whether center and radius should be aligned to powers of two. Aligning considerably
+         *                        reduces risk of precision problems. Recommended: "true".
+         * @param maxNodeCapacity Maximum entries in a node before the node is split. The default is 10.
+         * @param <T>             Value type
+         * @return New QuadtreeHC
+         */
+        static <T> BoxMap<T> createQuadtreeHC(double[] min, double[] max, boolean align, int maxNodeCapacity) {
+            return QuadTreeRKD.create(min, max, align, maxNodeCapacity);
         }
 
         /**

--- a/src/main/java/org/tinspin/index/BoxMultimap.java
+++ b/src/main/java/org/tinspin/index/BoxMultimap.java
@@ -145,7 +145,7 @@ public interface BoxMultimap<T> extends Index {
 
     interface Factory {
         /**
-         * Create an array backed BoxMap. This is only for testing and rather inefficient for large data sets.
+         * Create an array backed BoxMultiMap. This is only for testing and rather inefficient for large data sets.
          *
          * @param dims Number of dimensions.
          * @param size Number of entries.
@@ -168,6 +168,7 @@ public interface BoxMultimap<T> extends Index {
         }
 
         /**
+         * WARNING: Unaligned center and radius can cause precision problems, see README.
          * Create a plain Quadtree.
          * Min/max are used to find a good initial root. They do not need to be exact. If possible, min/max should
          * span an area that is somewhat larger rather than smaller than the actual data.
@@ -178,9 +179,30 @@ public interface BoxMultimap<T> extends Index {
          * @param max             Estimated maximum of all coordinates.
          * @param <T>             Value type
          * @return New Quadtree
+         * @deprecated Please use {@link #createQuadtree(double[], double[], boolean, int)}
          */
+        @Deprecated
         static <T> BoxMultimap<T> createQuadtree(int dims, int maxNodeCapacity, double[] min, double[] max) {
             return QuadTreeRKD0.create(dims, maxNodeCapacity, min, max);
+        }
+
+        /**
+         * Create a plain Quadtree.
+         * Min/max are used to find a good initial root. They do not need to be exact. If possible, min/max should
+         * span an area that is somewhat larger rather than smaller than the actual data.
+         * <p>
+         * Center and radius will be aligned with powers of two to avoid precision problems.
+         *
+         * @param min             Estimated minimum of all coordinates.
+         * @param max             Estimated maximum of all coordinates.
+         * @param align           Whether center and radius should be aligned to powers of two. Aligning considerably
+         *                        reduces risk of precision problems. Recommended: "true".
+         * @param maxNodeCapacity Maximum entries in a node before the node is split. The default is 10.
+         * @param <T>             Value type
+         * @return New Quadtree
+         */
+        static <T> BoxMultimap<T> createQuadtree(double[] min, double[] max, boolean align, int maxNodeCapacity) {
+            return QuadTreeRKD0.create(min, max, align, maxNodeCapacity);
         }
 
         /**
@@ -195,7 +217,8 @@ public interface BoxMultimap<T> extends Index {
         }
 
         /**
-         * Create a plain Quadtree.
+         * WARNING: Unaligned center and radius can cause precision problems, see README.
+         * Create a Quadtree with hypercube navigation.
          * Min/max are used to find a good initial root. They do not need to be exact. If possible, min/max should
          * span an area that is somewhat larger rather than smaller than the actual data.
          *
@@ -205,9 +228,30 @@ public interface BoxMultimap<T> extends Index {
          * @param max             Estimated maximum of all coordinates.
          * @param <T>             Value type
          * @return New QuadtreeHC
+         * @deprecated Please use {@link #createQuadtree(double[], double[], boolean, int)}
          */
+        @Deprecated
         static <T> BoxMultimap<T> createQuadtreeHC(int dims, int maxNodeCapacity, double[] min, double[] max) {
             return QuadTreeRKD.create(dims, maxNodeCapacity, min, max);
+        }
+
+        /**
+         * Create a Quadtree with hypercube navigation.
+         * Min/max are used to find a good initial root. They do not need to be exact. If possible, min/max should
+         * span an area that is somewhat larger rather than smaller than the actual data.
+         * <p>
+         * Center and radius will be aligned with powers of two to avoid precision problems.
+         *
+         * @param min             Estimated minimum of all coordinates.
+         * @param max             Estimated maximum of all coordinates.
+         * @param align           Whether center and radius should be aligned to powers of two. Aligning considerably
+         *                        reduces risk of precision problems. Recommended: "true".
+         * @param maxNodeCapacity Maximum entries in a node before the node is split. The default is 10.
+         * @param <T>             Value type
+         * @return New QuadtreeHC
+         */
+        static <T> BoxMultimap<T> createQuadtreeHC(double[] min, double[] max, boolean align, int maxNodeCapacity) {
+            return QuadTreeRKD.create(min, max, align, maxNodeCapacity);
         }
 
         /**

--- a/src/main/java/org/tinspin/index/PointMap.java
+++ b/src/main/java/org/tinspin/index/PointMap.java
@@ -185,6 +185,7 @@ public interface PointMap<T> extends Index {
         }
 
         /**
+         * WARNING: Unaligned center and radius can cause precision problems, see README.
          * Create a plain Quadtree.
          * Center/radius are used to find a good initial root. They do not need to be exact. If possible, they should
          * span an area that is somewhat larger rather than smaller than the actual data.
@@ -195,9 +196,29 @@ public interface PointMap<T> extends Index {
          * @param radius          Estimated maximum orthogonal distance from center for all coordinates.
          * @param <T>             Value type
          * @return New Quadtree
+         * @deprecated Please use {@link #createAlignedQuadtree(int, int, double[], double)}
          */
+        @Deprecated
         static <T> PointMap<T> createQuadtree(int dims, int maxNodeCapacity, double[] center, double radius) {
             return QuadTreeKD0.create(dims, maxNodeCapacity, center, radius);
+        }
+
+        /**
+         * Create a plain Quadtree.
+         * Center/radius are used to find a good initial root. They do not need to be exact. If possible, they should
+         * span an area that is somewhat larger rather than smaller than the actual data.
+         * <p>
+         * Center and radius will be aligned with powers of two to avoid precision problems.
+         *
+         * @param dims            Number of dimensions.
+         * @param maxNodeCapacity Maximum entries in a node before the node is split. The default is 10.
+         * @param center          Estimated center of all coordinates.
+         * @param radius          Estimated maximum orthogonal distance from center for all coordinates.
+         * @param <T>             Value type
+         * @return New Quadtree
+         */
+        static <T> PointMap<T> createAlignedQuadtree(int dims, int maxNodeCapacity, double[] center, double radius) {
+            return QuadTreeKD0.createAligned(dims, maxNodeCapacity, center, radius);
         }
 
         /**
@@ -212,7 +233,8 @@ public interface PointMap<T> extends Index {
         }
 
         /**
-         * Create a plain Quadtree.
+         * WARNING: Unaligned center and radius can cause precision problems, see README.
+         * Create a Quadtree with hypercube navigation.
          * Center/radius are used to find a good initial root. They do not need to be exact. If possible, they should
          * span an area that is somewhat larger rather than smaller than the actual data.
          *
@@ -222,13 +244,33 @@ public interface PointMap<T> extends Index {
          * @param radius          Estimated maximum orthogonal distance from center for all coordinates.
          * @param <T>             Value type
          * @return New QuadtreeHC
+         * @deprecated Please use {@link #createAlignedQuadtreeHC(int, int, double[], double)}
          */
+        @Deprecated
         static <T> PointMap<T> createQuadtreeHC(int dims, int maxNodeCapacity, double[] center, double radius) {
             return QuadTreeKD.create(dims, maxNodeCapacity, center, radius);
         }
 
         /**
          * Create a Quadtree with hypercube navigation.
+         * Center/radius are used to find a good initial root. They do not need to be exact. If possible, they should
+         * span an area that is somewhat larger rather than smaller than the actual data.
+         * <p>
+         * Center and radius will be aligned with powers of two to avoid precision problems.
+         *
+         * @param dims            Number of dimensions.
+         * @param maxNodeCapacity Maximum entries in a node before the node is split. The default is 10.
+         * @param center          Estimated center of all coordinates.
+         * @param radius          Estimated maximum orthogonal distance from center for all coordinates.
+         * @param <T>             Value type
+         * @return New QuadtreeHC
+         */
+        static <T> PointMap<T> createAlignedQuadtreeHC(int dims, int maxNodeCapacity, double[] center, double radius) {
+            return QuadTreeKD.createAligned(dims, maxNodeCapacity, center, radius);
+        }
+
+        /**
+         * Create a Quadtree with extended hypercube navigation.
          *
          * @param dims Number of dimensions.
          * @param <T>  Value type
@@ -239,7 +281,7 @@ public interface PointMap<T> extends Index {
         }
 
         /**
-         * Create a plain Quadtree.
+         * Create a Quadtree with extended hypercube navigation.
          * Center/radius are used to find a good initial root. They do not need to be exact. If possible, they should
          * span an area that is somewhat larger rather than smaller than the actual data.
          *
@@ -249,9 +291,29 @@ public interface PointMap<T> extends Index {
          * @param radius          Estimated maximum orthogonal distance from center for all coordinates.
          * @param <T>             Value type
          * @return New QuadtreeHC2
+         * @deprecated PLease use {@link #createAlignedQuadtreeHC2(int, int, double[], double)}
          */
+        @Deprecated
         static <T> PointMap<T> createQuadtreeHC2(int dims, int maxNodeCapacity, double[] center, double radius) {
             return QuadTreeKD2.create(dims, maxNodeCapacity, center, radius);
+        }
+
+        /**
+         * Create a Quadtree with extended hypercube navigation.
+         * Center/radius are used to find a good initial root. They do not need to be exact. If possible, they should
+         * span an area that is somewhat larger rather than smaller than the actual data.
+         * <p>
+         * Center and radius will be aligned with powers of two to avoid precision problems.
+         *
+         * @param dims            Number of dimensions.
+         * @param maxNodeCapacity Maximum entries in a node before the node is split. The default is 10.
+         * @param center          Estimated center of all coordinates.
+         * @param radius          Estimated maximum orthogonal distance from center for all coordinates.
+         * @param <T>             Value type
+         * @return New QuadtreeHC2
+         */
+        static <T> PointMap<T> createAlignedQuadtreeHC2(int dims, int maxNodeCapacity, double[] center, double radius) {
+            return QuadTreeKD2.createAligned(dims, maxNodeCapacity, center, radius);
         }
 
         /**

--- a/src/main/java/org/tinspin/index/PointMap.java
+++ b/src/main/java/org/tinspin/index/PointMap.java
@@ -283,6 +283,7 @@ public interface PointMap<T> extends Index {
         }
 
         /**
+         * WARNING: Unaligned center and radius can cause precision problems, see README.
          * Create a Quadtree with extended hypercube navigation.
          * Center/radius are used to find a good initial root. They do not need to be exact. If possible, they should
          * span an area that is somewhat larger rather than smaller than the actual data.
@@ -293,7 +294,7 @@ public interface PointMap<T> extends Index {
          * @param radius          Estimated maximum orthogonal distance from center for all coordinates.
          * @param <T>             Value type
          * @return New QuadtreeHC2
-         * @deprecated PLease use {@link #createQuadtreeHC2(double[], double, boolean, int)}
+         * @deprecated Please use {@link #createQuadtreeHC2(double[], double, boolean, int)}
          */
         @Deprecated
         static <T> PointMap<T> createQuadtreeHC2(int dims, int maxNodeCapacity, double[] center, double radius) {

--- a/src/main/java/org/tinspin/index/PointMap.java
+++ b/src/main/java/org/tinspin/index/PointMap.java
@@ -196,7 +196,7 @@ public interface PointMap<T> extends Index {
          * @param radius          Estimated maximum orthogonal distance from center for all coordinates.
          * @param <T>             Value type
          * @return New Quadtree
-         * @deprecated Please use {@link #createAlignedQuadtree(int, int, double[], double)}
+         * @deprecated Please use {@link #createQuadtree(double[], double, boolean, int)}
          */
         @Deprecated
         static <T> PointMap<T> createQuadtree(int dims, int maxNodeCapacity, double[] center, double radius) {
@@ -210,15 +210,16 @@ public interface PointMap<T> extends Index {
          * <p>
          * Center and radius will be aligned with powers of two to avoid precision problems.
          *
-         * @param dims            Number of dimensions.
-         * @param maxNodeCapacity Maximum entries in a node before the node is split. The default is 10.
          * @param center          Estimated center of all coordinates.
          * @param radius          Estimated maximum orthogonal distance from center for all coordinates.
+         * @param align           Whether center and radius should be aligned to powers of two. Aligning considerably
+         *                        reduces risk of precision problems. Recommended: "true".
+         * @param maxNodeCapacity Maximum entries in a node before the node is split. The default is 10.
          * @param <T>             Value type
          * @return New Quadtree
          */
-        static <T> PointMap<T> createAlignedQuadtree(int dims, int maxNodeCapacity, double[] center, double radius) {
-            return QuadTreeKD0.createAligned(dims, maxNodeCapacity, center, radius);
+        static <T> PointMap<T> createQuadtree(double[] center, double radius, boolean align, int maxNodeCapacity) {
+            return QuadTreeKD0.create(center, radius, align, maxNodeCapacity);
         }
 
         /**
@@ -244,7 +245,7 @@ public interface PointMap<T> extends Index {
          * @param radius          Estimated maximum orthogonal distance from center for all coordinates.
          * @param <T>             Value type
          * @return New QuadtreeHC
-         * @deprecated Please use {@link #createAlignedQuadtreeHC(int, int, double[], double)}
+         * @deprecated Please use {@link #createQuadtreeHC(double[], double, boolean, int)}
          */
         @Deprecated
         static <T> PointMap<T> createQuadtreeHC(int dims, int maxNodeCapacity, double[] center, double radius) {
@@ -258,15 +259,16 @@ public interface PointMap<T> extends Index {
          * <p>
          * Center and radius will be aligned with powers of two to avoid precision problems.
          *
-         * @param dims            Number of dimensions.
-         * @param maxNodeCapacity Maximum entries in a node before the node is split. The default is 10.
          * @param center          Estimated center of all coordinates.
          * @param radius          Estimated maximum orthogonal distance from center for all coordinates.
+         * @param align           Whether center and radius should be aligned to powers of two. Aligning considerably
+         *                        reduces risk of precision problems. Recommended: "true".
+         * @param maxNodeCapacity Maximum entries in a node before the node is split. The default is 10.
          * @param <T>             Value type
          * @return New QuadtreeHC
          */
-        static <T> PointMap<T> createAlignedQuadtreeHC(int dims, int maxNodeCapacity, double[] center, double radius) {
-            return QuadTreeKD.createAligned(dims, maxNodeCapacity, center, radius);
+        static <T> PointMap<T> createQuadtreeHC(double[] center, double radius, boolean align, int maxNodeCapacity) {
+            return QuadTreeKD.create(center, radius, align, maxNodeCapacity);
         }
 
         /**
@@ -291,7 +293,7 @@ public interface PointMap<T> extends Index {
          * @param radius          Estimated maximum orthogonal distance from center for all coordinates.
          * @param <T>             Value type
          * @return New QuadtreeHC2
-         * @deprecated PLease use {@link #createAlignedQuadtreeHC2(int, int, double[], double)}
+         * @deprecated PLease use {@link #createQuadtreeHC2(double[], double, boolean, int)}
          */
         @Deprecated
         static <T> PointMap<T> createQuadtreeHC2(int dims, int maxNodeCapacity, double[] center, double radius) {
@@ -305,15 +307,16 @@ public interface PointMap<T> extends Index {
          * <p>
          * Center and radius will be aligned with powers of two to avoid precision problems.
          *
-         * @param dims            Number of dimensions.
-         * @param maxNodeCapacity Maximum entries in a node before the node is split. The default is 10.
          * @param center          Estimated center of all coordinates.
          * @param radius          Estimated maximum orthogonal distance from center for all coordinates.
+         * @param align           Whether center and radius should be aligned to powers of two. Aligning considerably
+         *                        reduces risk of precision problems. Recommended: "true".
+         * @param maxNodeCapacity Maximum entries in a node before the node is split. The default is 10.
          * @param <T>             Value type
          * @return New QuadtreeHC2
          */
-        static <T> PointMap<T> createAlignedQuadtreeHC2(int dims, int maxNodeCapacity, double[] center, double radius) {
-            return QuadTreeKD2.createAligned(dims, maxNodeCapacity, center, radius);
+        static <T> PointMap<T> createQuadtreeHC2(double[] center, double radius, boolean align, int maxNodeCapacity) {
+            return QuadTreeKD2.create(center, radius, align, maxNodeCapacity);
         }
 
         /**

--- a/src/main/java/org/tinspin/index/PointMultimap.java
+++ b/src/main/java/org/tinspin/index/PointMultimap.java
@@ -143,7 +143,7 @@ public interface PointMultimap<T> extends Index {
 
     interface Factory {
         /**
-         * Create an array backed PointMap. This is only for testing and rather inefficient for large data sets.
+         * Create an array backed PointMultiMap. This is only for testing and rather inefficient for large data sets.
          *
          * @param dims Number of dimensions.
          * @param size Number of entries.
@@ -307,7 +307,7 @@ public interface PointMultimap<T> extends Index {
          * @param radius          Estimated maximum orthogonal distance from center for all coordinates.
          * @param <T>             Value type
          * @return New QuadtreeHC2
-         * @deprecated PLease use {@link #createQuadtreeHC2(double[], double, boolean, int)}
+         * @deprecated Please use {@link #createQuadtreeHC2(double[], double, boolean, int)}
          */
         @Deprecated
         static <T> PointMultimap<T> createQuadtreeHC2(int dims, int maxNodeCapacity, double[] center, double radius) {

--- a/src/main/java/org/tinspin/index/PointMultimap.java
+++ b/src/main/java/org/tinspin/index/PointMultimap.java
@@ -199,6 +199,7 @@ public interface PointMultimap<T> extends Index {
         }
 
         /**
+         * WARNING: Unaligned center and radius can cause precision problems, see README.
          * Create a plain Quadtree.
          * Center/radius are used to find a good initial root. They do not need to be exact. If possible, they should
          * span an area that is somewhat larger rather than smaller than the actual data.
@@ -209,9 +210,29 @@ public interface PointMultimap<T> extends Index {
          * @param radius          Estimated maximum orthogonal distance from center for all coordinates.
          * @param <T>             Value type
          * @return New Quadtree
+         * @deprecated Please use {@link #createAlignedQuadtree(int, int, double[], double)}
          */
+        @Deprecated
         static <T> PointMultimap<T> createQuadtree(int dims, int maxNodeCapacity, double[] center, double radius) {
             return QuadTreeKD0.create(dims, maxNodeCapacity, center, radius);
+        }
+
+        /**
+         * Create a plain Quadtree.
+         * Center/radius are used to find a good initial root. They do not need to be exact. If possible, they should
+         * span an area that is somewhat larger rather than smaller than the actual data.
+         * <p>
+         * Center and radius will be aligned with powers of two to avoid precision problems.
+         *
+         * @param dims            Number of dimensions.
+         * @param maxNodeCapacity Maximum entries in a node before the node is split. The default is 10.
+         * @param center          Estimated center of all coordinates.
+         * @param radius          Estimated maximum orthogonal distance from center for all coordinates.
+         * @param <T>             Value type
+         * @return New Quadtree
+         */
+        static <T> PointMultimap<T> createAlignedQuadtree(int dims, int maxNodeCapacity, double[] center, double radius) {
+            return QuadTreeKD0.createAligned(dims, maxNodeCapacity, center, radius);
         }
 
         /**
@@ -226,7 +247,8 @@ public interface PointMultimap<T> extends Index {
         }
 
         /**
-         * Create a plain Quadtree.
+         * WARNING: Unaligned center and radius can cause precision problems, see README.
+         * Create a Quadtree with hypercube navigation.
          * Center/radius are used to find a good initial root. They do not need to be exact. If possible, they should
          * span an area that is somewhat larger rather than smaller than the actual data.
          *
@@ -236,13 +258,33 @@ public interface PointMultimap<T> extends Index {
          * @param radius          Estimated maximum orthogonal distance from center for all coordinates.
          * @param <T>             Value type
          * @return New QuadtreeHC
+         * @deprecated Please use {@link #createAlignedQuadtreeHC(int, int, double[], double)}
          */
+        @Deprecated
         static <T> PointMultimap<T> createQuadtreeHC(int dims, int maxNodeCapacity, double[] center, double radius) {
             return QuadTreeKD.create(dims, maxNodeCapacity, center, radius);
         }
 
         /**
          * Create a Quadtree with hypercube navigation.
+         * Center/radius are used to find a good initial root. They do not need to be exact. If possible, they should
+         * span an area that is somewhat larger rather than smaller than the actual data.
+         * <p>
+         * Center and radius will be aligned with powers of two to avoid precision problems.
+         *
+         * @param dims            Number of dimensions.
+         * @param maxNodeCapacity Maximum entries in a node before the node is split. The default is 10.
+         * @param center          Estimated center of all coordinates.
+         * @param radius          Estimated maximum orthogonal distance from center for all coordinates.
+         * @param <T>             Value type
+         * @return New QuadtreeHC
+         */
+        static <T> PointMultimap<T> createAlignedQuadtreeHC(int dims, int maxNodeCapacity, double[] center, double radius) {
+            return QuadTreeKD.createAligned(dims, maxNodeCapacity, center, radius);
+        }
+
+        /**
+         * Create a Quadtree with extended hypercube navigation.
          *
          * @param dims Number of dimensions.
          * @param <T>  Value type
@@ -253,7 +295,7 @@ public interface PointMultimap<T> extends Index {
         }
 
         /**
-         * Create a plain Quadtree.
+         * Create a Quadtree with extended hypercube navigation.
          * Center/radius are used to find a good initial root. They do not need to be exact. If possible, they should
          * span an area that is somewhat larger rather than smaller than the actual data.
          *
@@ -263,9 +305,29 @@ public interface PointMultimap<T> extends Index {
          * @param radius          Estimated maximum orthogonal distance from center for all coordinates.
          * @param <T>             Value type
          * @return New QuadtreeHC2
+         * @deprecated PLease use {@link #createAlignedQuadtreeHC2(int, int, double[], double)}
          */
+        @Deprecated
         static <T> PointMultimap<T> createQuadtreeHC2(int dims, int maxNodeCapacity, double[] center, double radius) {
             return QuadTreeKD2.create(dims, maxNodeCapacity, center, radius);
+        }
+
+        /**
+         * Create a Quadtree with extended hypercube navigation.
+         * Center/radius are used to find a good initial root. They do not need to be exact. If possible, they should
+         * span an area that is somewhat larger rather than smaller than the actual data.
+         * <p>
+         * Center and radius will be aligned with powers of two to avoid precision problems.
+         *
+         * @param dims            Number of dimensions.
+         * @param maxNodeCapacity Maximum entries in a node before the node is split. The default is 10.
+         * @param center          Estimated center of all coordinates.
+         * @param radius          Estimated maximum orthogonal distance from center for all coordinates.
+         * @param <T>             Value type
+         * @return New QuadtreeHC2
+         */
+        static <T> PointMultimap<T> createAlignedQuadtreeHC2(int dims, int maxNodeCapacity, double[] center, double radius) {
+            return QuadTreeKD2.createAligned(dims, maxNodeCapacity, center, radius);
         }
 
         /**

--- a/src/main/java/org/tinspin/index/PointMultimap.java
+++ b/src/main/java/org/tinspin/index/PointMultimap.java
@@ -210,7 +210,7 @@ public interface PointMultimap<T> extends Index {
          * @param radius          Estimated maximum orthogonal distance from center for all coordinates.
          * @param <T>             Value type
          * @return New Quadtree
-         * @deprecated Please use {@link #createAlignedQuadtree(int, int, double[], double)}
+         * @deprecated Please use {@link #createQuadtree(double[], double, boolean, int)}
          */
         @Deprecated
         static <T> PointMultimap<T> createQuadtree(int dims, int maxNodeCapacity, double[] center, double radius) {
@@ -224,15 +224,16 @@ public interface PointMultimap<T> extends Index {
          * <p>
          * Center and radius will be aligned with powers of two to avoid precision problems.
          *
-         * @param dims            Number of dimensions.
-         * @param maxNodeCapacity Maximum entries in a node before the node is split. The default is 10.
          * @param center          Estimated center of all coordinates.
          * @param radius          Estimated maximum orthogonal distance from center for all coordinates.
+         * @param align           Whether center and radius should be aligned to powers of two. Aligning considerably
+         *                        reduces risk of precision problems. Recommended: "true".
+         * @param maxNodeCapacity Maximum entries in a node before the node is split. The default is 10.
          * @param <T>             Value type
          * @return New Quadtree
          */
-        static <T> PointMultimap<T> createAlignedQuadtree(int dims, int maxNodeCapacity, double[] center, double radius) {
-            return QuadTreeKD0.createAligned(dims, maxNodeCapacity, center, radius);
+        static <T> PointMultimap<T> createQuadtree(double[] center, double radius, boolean align, int maxNodeCapacity) {
+            return QuadTreeKD0.create(center, radius, align, maxNodeCapacity);
         }
 
         /**
@@ -258,7 +259,7 @@ public interface PointMultimap<T> extends Index {
          * @param radius          Estimated maximum orthogonal distance from center for all coordinates.
          * @param <T>             Value type
          * @return New QuadtreeHC
-         * @deprecated Please use {@link #createAlignedQuadtreeHC(int, int, double[], double)}
+         * @deprecated Please use {@link #createQuadtreeHC(double[], double, boolean, int)}
          */
         @Deprecated
         static <T> PointMultimap<T> createQuadtreeHC(int dims, int maxNodeCapacity, double[] center, double radius) {
@@ -272,15 +273,16 @@ public interface PointMultimap<T> extends Index {
          * <p>
          * Center and radius will be aligned with powers of two to avoid precision problems.
          *
-         * @param dims            Number of dimensions.
-         * @param maxNodeCapacity Maximum entries in a node before the node is split. The default is 10.
          * @param center          Estimated center of all coordinates.
          * @param radius          Estimated maximum orthogonal distance from center for all coordinates.
+         * @param align           Whether center and radius should be aligned to powers of two. Aligning considerably
+         *                        reduces risk of precision problems. Recommended: "true".
+         * @param maxNodeCapacity Maximum entries in a node before the node is split. The default is 10.
          * @param <T>             Value type
          * @return New QuadtreeHC
          */
-        static <T> PointMultimap<T> createAlignedQuadtreeHC(int dims, int maxNodeCapacity, double[] center, double radius) {
-            return QuadTreeKD.createAligned(dims, maxNodeCapacity, center, radius);
+        static <T> PointMultimap<T> createQuadtreeHC(double[] center, double radius, boolean align, int maxNodeCapacity) {
+            return QuadTreeKD.create(center, radius, align, maxNodeCapacity);
         }
 
         /**
@@ -305,7 +307,7 @@ public interface PointMultimap<T> extends Index {
          * @param radius          Estimated maximum orthogonal distance from center for all coordinates.
          * @param <T>             Value type
          * @return New QuadtreeHC2
-         * @deprecated PLease use {@link #createAlignedQuadtreeHC2(int, int, double[], double)}
+         * @deprecated PLease use {@link #createQuadtreeHC2(double[], double, boolean, int)}
          */
         @Deprecated
         static <T> PointMultimap<T> createQuadtreeHC2(int dims, int maxNodeCapacity, double[] center, double radius) {
@@ -319,15 +321,16 @@ public interface PointMultimap<T> extends Index {
          * <p>
          * Center and radius will be aligned with powers of two to avoid precision problems.
          *
-         * @param dims            Number of dimensions.
-         * @param maxNodeCapacity Maximum entries in a node before the node is split. The default is 10.
          * @param center          Estimated center of all coordinates.
          * @param radius          Estimated maximum orthogonal distance from center for all coordinates.
+         * @param align           Whether center and radius should be aligned to powers of two. Aligning considerably
+         *                        reduces risk of precision problems. Recommended: "true".
+         * @param maxNodeCapacity Maximum entries in a node before the node is split. The default is 10.
          * @param <T>             Value type
          * @return New QuadtreeHC2
          */
-        static <T> PointMultimap<T> createAlignedQuadtreeHC2(int dims, int maxNodeCapacity, double[] center, double radius) {
-            return QuadTreeKD2.createAligned(dims, maxNodeCapacity, center, radius);
+        static <T> PointMultimap<T> createQuadtreeHC2(double[] center, double radius, boolean align, int maxNodeCapacity) {
+            return QuadTreeKD2.create(center, radius, align, maxNodeCapacity);
         }
 
         /**

--- a/src/main/java/org/tinspin/index/qthypercube/QuadTreeKD.java
+++ b/src/main/java/org/tinspin/index/qthypercube/QuadTreeKD.java
@@ -73,9 +73,41 @@ public class QuadTreeKD<T> implements PointMap<T>, PointMultimap<T> {
 	public static <T> QuadTreeKD<T> create(int dims, int maxNodeSize) {
 		return new QuadTreeKD<>(dims, maxNodeSize);
 	}
-	
-	public static <T> QuadTreeKD<T> create(int dims, int maxNodeSize, 
-			double[] center, double radius) {
+
+	/**
+	 * Note: This will align center and radius to a power of two before creating a tree.
+	 * @param dims dimensions, usually 2 or 3
+	 * @param maxNodeSize maximum entries per node, default is 10
+	 * @param center center of initial root node
+	 * @param radius radius of initial root node
+	 * @return New quadtree
+	 * @param <T> Value type
+	 */
+	public static <T> QuadTreeKD<T> createAligned(int dims, int maxNodeSize,
+										   double[] center, double radius) {
+		QuadTreeKD<T> t = new QuadTreeKD<>(dims, maxNodeSize);
+		if (radius <= 0) {
+			throw new IllegalArgumentException("Radius must be > 0 but was " + radius);
+		}
+		double[] alignedCenter = MathTools.floorPowerOfTwoCopy(center);
+		double alignedRadius = MathTools.ceilPowerOfTwo(radius);
+		t.root = new QNode<>(Arrays.copyOf(alignedCenter, alignedCenter.length), alignedRadius);
+		return t;
+	}
+
+	/**
+	 * WARNING: Unaligned center and radius can cause precision problems.
+	 * @param dims dimensions, usually 2 or 3
+	 * @param maxNodeSize maximum entries per node, default is 10
+	 * @param center center of initial root node
+	 * @param radius radius of initial root node
+	 * @return New quadtree
+	 * @param <T> Value type
+	 * @deprecated Please use {@link #createAligned(int, int, double[], double)}
+	 */
+	@Deprecated
+	public static <T> QuadTreeKD<T> create(int dims, int maxNodeSize,
+										   double[] center, double radius) {
 		QuadTreeKD<T> t = new QuadTreeKD<>(dims, maxNodeSize);
 		if (radius <= 0) {
 			throw new IllegalArgumentException("Radius must be > 0 but was " + radius);

--- a/src/main/java/org/tinspin/index/qthypercube/QuadTreeKD.java
+++ b/src/main/java/org/tinspin/index/qthypercube/QuadTreeKD.java
@@ -76,22 +76,24 @@ public class QuadTreeKD<T> implements PointMap<T>, PointMultimap<T> {
 
 	/**
 	 * Note: This will align center and radius to a power of two before creating a tree.
-	 * @param dims dimensions, usually 2 or 3
-	 * @param maxNodeSize maximum entries per node, default is 10
 	 * @param center center of initial root node
 	 * @param radius radius of initial root node
+	 * @param maxNodeSize maximum entries per node, default is 10
+	 * @param align Whether center and radius should be aligned to powers of two. Aligning considerably
+	 *              reduces risk of precision problems. Recommended: "true".
 	 * @return New quadtree
 	 * @param <T> Value type
 	 */
-	public static <T> QuadTreeKD<T> createAligned(int dims, int maxNodeSize,
-										   double[] center, double radius) {
-		QuadTreeKD<T> t = new QuadTreeKD<>(dims, maxNodeSize);
+	public static <T> QuadTreeKD<T> create(double[] center, double radius, boolean align, int maxNodeSize) {
+		QuadTreeKD<T> t = new QuadTreeKD<>(center.length, maxNodeSize);
 		if (radius <= 0) {
 			throw new IllegalArgumentException("Radius must be > 0 but was " + radius);
 		}
-		double[] alignedCenter = MathTools.floorPowerOfTwoCopy(center);
-		double alignedRadius = MathTools.ceilPowerOfTwo(radius);
-		t.root = new QNode<>(Arrays.copyOf(alignedCenter, alignedCenter.length), alignedRadius);
+		if (align) {
+			center = MathTools.floorPowerOfTwoCopy(center);
+			radius = MathTools.ceilPowerOfTwo(radius);
+		}
+		t.root = new QNode<>(Arrays.copyOf(center, center.length), radius);
 		return t;
 	}
 
@@ -103,7 +105,7 @@ public class QuadTreeKD<T> implements PointMap<T>, PointMultimap<T> {
 	 * @param radius radius of initial root node
 	 * @return New quadtree
 	 * @param <T> Value type
-	 * @deprecated Please use {@link #createAligned(int, int, double[], double)}
+	 * @deprecated Please use {@link #create(double[], double, boolean, int)}
 	 */
 	@Deprecated
 	public static <T> QuadTreeKD<T> create(int dims, int maxNodeSize,

--- a/src/main/java/org/tinspin/index/qthypercube2/QuadTreeKD2.java
+++ b/src/main/java/org/tinspin/index/qthypercube2/QuadTreeKD2.java
@@ -101,22 +101,24 @@ public class QuadTreeKD2<T> implements PointMap<T>, PointMultimap<T> {
 
 	/**
 	 * Note: This will align center and radius to a power of two before creating a tree.
-	 * @param dims dimensions, usually 2 or 3
-	 * @param maxNodeSize maximum entries per node, default is 10
 	 * @param center center of initial root node
 	 * @param radius radius of initial root node
+	 * @param align Whether center and radius should be aligned to powers of two. Aligning considerably
+	 *              reduces risk of precision problems. Recommended: "true".
+	 * @param maxNodeSize maximum entries per node, default is 10
 	 * @return New quadtree
 	 * @param <T> Value type
 	 */
-	public static <T> QuadTreeKD2<T> createAligned(int dims, int maxNodeSize,
-											double[] center, double radius) {
-		QuadTreeKD2<T> t = new QuadTreeKD2<>(dims, maxNodeSize);
+	public static <T> QuadTreeKD2<T> create(double[] center, double radius, boolean align, int maxNodeSize) {
+		QuadTreeKD2<T> t = new QuadTreeKD2<>(center.length, maxNodeSize);
 		if (radius <= 0) {
 			throw new IllegalArgumentException("Radius must be > 0 but was " + radius);
 		}
-		double[] alignedCenter = MathTools.floorPowerOfTwoCopy(center);
-		double alignedRadius = MathTools.ceilPowerOfTwo(radius);
-		t.root = new QNode<>(Arrays.copyOf(alignedCenter, alignedCenter.length), alignedRadius);
+		if (align) {
+			center = MathTools.floorPowerOfTwoCopy(center);
+			radius = MathTools.ceilPowerOfTwo(radius);
+		}
+		t.root = new QNode<>(Arrays.copyOf(center, center.length), radius);
 		return t;
 	}
 
@@ -128,7 +130,7 @@ public class QuadTreeKD2<T> implements PointMap<T>, PointMultimap<T> {
 	 * @param radius radius of initial root node
 	 * @return New quadtree
 	 * @param <T> Value type
-	 * @deprecated Please use {@link #createAligned(int, int, double[], double)}
+	 * @deprecated Please use {@link #create(double[], double, boolean, int)}
 	 */
 	@Deprecated
 	public static <T> QuadTreeKD2<T> create(int dims, int maxNodeSize, 

--- a/src/main/java/org/tinspin/index/qthypercube2/QuadTreeKD2.java
+++ b/src/main/java/org/tinspin/index/qthypercube2/QuadTreeKD2.java
@@ -65,8 +65,8 @@ public class QuadTreeKD2<T> implements PointMap<T>, PointMultimap<T> {
 	private final int dims;
 	private final int maxNodeSize;
 	private QNode<T> root = null;
-	private int size = 0; 
-	
+	private int size = 0;
+
 
 	private QuadTreeKD2(int dims, int maxNodeSize) {
 		if (DEBUG) {
@@ -76,6 +76,11 @@ public class QuadTreeKD2<T> implements PointMap<T>, PointMultimap<T> {
 		this.maxNodeSize = maxNodeSize;
 	}
 
+	/**
+	 * @param dims dimensions, usually 2 or 3
+	 * @return New quadtree
+	 * @param <T> Value type
+	 */
 	public static <T> QuadTreeKD2<T> create(int dims) {
 		int maxNodeSize = DEFAULT_MAX_NODE_SIZE;
 		if (2 * dims > DEFAULT_MAX_NODE_SIZE) {
@@ -83,11 +88,49 @@ public class QuadTreeKD2<T> implements PointMap<T>, PointMultimap<T> {
 		}
 		return new QuadTreeKD2<>(dims, maxNodeSize);
 	}
-	
+
+	/**
+	 * @param dims dimensions, usually 2 or 3
+	 * @param maxNodeSize maximum entries per node, default is 10
+	 * @return New quadtree
+	 * @param <T> Value type
+	 */
 	public static <T> QuadTreeKD2<T> create(int dims, int maxNodeSize) {
 		return new QuadTreeKD2<>(dims, maxNodeSize);
 	}
-	
+
+	/**
+	 * Note: This will align center and radius to a power of two before creating a tree.
+	 * @param dims dimensions, usually 2 or 3
+	 * @param maxNodeSize maximum entries per node, default is 10
+	 * @param center center of initial root node
+	 * @param radius radius of initial root node
+	 * @return New quadtree
+	 * @param <T> Value type
+	 */
+	public static <T> QuadTreeKD2<T> createAligned(int dims, int maxNodeSize,
+											double[] center, double radius) {
+		QuadTreeKD2<T> t = new QuadTreeKD2<>(dims, maxNodeSize);
+		if (radius <= 0) {
+			throw new IllegalArgumentException("Radius must be > 0 but was " + radius);
+		}
+		double[] alignedCenter = MathTools.floorPowerOfTwoCopy(center);
+		double alignedRadius = MathTools.ceilPowerOfTwo(radius);
+		t.root = new QNode<>(Arrays.copyOf(alignedCenter, alignedCenter.length), alignedRadius);
+		return t;
+	}
+
+	/**
+	 * WARNING: Unaligned center and radius can cause precision problems.
+	 * @param dims dimensions, usually 2 or 3
+	 * @param maxNodeSize maximum entries per node, default is 10
+	 * @param center center of initial root node
+	 * @param radius radius of initial root node
+	 * @return New quadtree
+	 * @param <T> Value type
+	 * @deprecated Please use {@link #createAligned(int, int, double[], double)}
+	 */
+	@Deprecated
 	public static <T> QuadTreeKD2<T> create(int dims, int maxNodeSize, 
 			double[] center, double radius) {
 		QuadTreeKD2<T> t = new QuadTreeKD2<>(dims, maxNodeSize);

--- a/src/main/java/org/tinspin/index/qthypercube2/QuadTreeKD2.java
+++ b/src/main/java/org/tinspin/index/qthypercube2/QuadTreeKD2.java
@@ -109,6 +109,8 @@ public class QuadTreeKD2<T> implements PointMap<T>, PointMultimap<T> {
 		PointEntry<T> e = new PointEntry<>(key, value);
 		if (root == null) {
 			// We calculate a better radius when adding a second point.
+			// We align the center to a power of two. That reduces precision problems when
+			// creating subnode centers.
 			root = new QNode<>(MathTools.floorPowerOfTwoCopy(key), INITIAL_RADIUS);
 		}
 		if (root.getRadius() == INITIAL_RADIUS) {
@@ -128,10 +130,14 @@ public class QuadTreeKD2<T> implements PointMap<T>, PointMultimap<T> {
 			return;
 		}
 		if (root.getRadius() == INITIAL_RADIUS) {
+			// Root size has not been initialized yet.
+			// We start by getting the maximum horizontal distance between the node center and any point in the node
 			double dMax = MathTools.maxDelta(key, root.getCenter());
 			for (int i = 0; i < root.getValueCount(); i++) {
 				dMax = Math.max(dMax, MathTools.maxDelta(root.getValues()[i].point(), root.getCenter()));
 			}
+			// We calculate the minimum required radius that is also a power of two.
+			// This radius can be divided by 2 many times without precision problems.
 			double radius = MathTools.ceilPowerOfTwo(dMax + QUtil.EPS_MUL);
 			if (radius > 0) {
 				root.adjustRadius(radius);

--- a/src/main/java/org/tinspin/index/qtplain/QuadTreeKD0.java
+++ b/src/main/java/org/tinspin/index/qtplain/QuadTreeKD0.java
@@ -67,21 +67,23 @@ public class QuadTreeKD0<T> implements PointMap<T>, PointMultimap<T> {
 
 	/**
 	 * Note: This will align center and radius to a power of two before creating a tree.
-	 * @param dims dimensions, usually 2 or 3
 	 * @param maxNodeSize maximum entries per node, default is 10
 	 * @param center center of initial root node
 	 * @param radius radius of initial root node
+	 * @param align Whether center and radius should be aligned to powers of two. Aligning considerably
+	 *              reduces risk of precision problems. Recommended: "true".
 	 * @return New quadtree
 	 * @param <T> Value type
-	 */	public static <T> QuadTreeKD0<T> createAligned(int dims, int maxNodeSize,
-											double[] center, double radius) {
-		QuadTreeKD0<T> t = new QuadTreeKD0<>(dims, maxNodeSize);
+	 */	public static <T> QuadTreeKD0<T> create(double[] center, double radius, boolean align, int maxNodeSize) {
+		QuadTreeKD0<T> t = new QuadTreeKD0<>(center.length, maxNodeSize);
 		if (radius <= 0) {
 			throw new IllegalArgumentException("Radius must be > 0 but was " + radius);
 		}
-		double[] alignedCenter = MathTools.floorPowerOfTwoCopy(center);
-		double alignedRadius = MathTools.ceilPowerOfTwo(radius);
-		t.root = new QNode<>(Arrays.copyOf(alignedCenter, alignedCenter.length), alignedRadius);
+		if (align) {
+			center = MathTools.floorPowerOfTwoCopy(center);
+			radius = MathTools.ceilPowerOfTwo(radius);
+		}
+		t.root = new QNode<>(Arrays.copyOf(center, center.length), radius);
 		return t;
 	}
 
@@ -93,7 +95,7 @@ public class QuadTreeKD0<T> implements PointMap<T>, PointMultimap<T> {
 	 * @param radius radius of initial root node
 	 * @return New quadtree
 	 * @param <T> Value type
-	 * @deprecated Please use {@link #createAligned(int, int, double[], double)}
+	 * @deprecated Please use {@link #create(double[], double, boolean, int)}
 	 */
 	@Deprecated
 	public static <T> QuadTreeKD0<T> create(int dims, int maxNodeSize,

--- a/src/main/java/org/tinspin/index/qtplain/QuadTreeRKD0.java
+++ b/src/main/java/org/tinspin/index/qtplain/QuadTreeRKD0.java
@@ -21,8 +21,10 @@ import java.util.*;
 import java.util.function.Predicate;
 
 import org.tinspin.index.*;
+import org.tinspin.index.qthypercube.QuadTreeRKD;
 import org.tinspin.index.qtplain.QuadTreeKD0.QStats;
 import org.tinspin.index.util.BoxIteratorWrapper;
+import org.tinspin.index.util.MathTools;
 import org.tinspin.index.util.StringBuilderLn;
 
 /**
@@ -56,25 +58,75 @@ public class QuadTreeRKD0<T> implements BoxMap<T>, BoxMultimap<T> {
 	public static <T> QuadTreeRKD0<T> create(int dims, int maxNodeSize) {
 		return new QuadTreeRKD0<>(dims, maxNodeSize);
 	}
-	
-	public static <T> QuadTreeRKD0<T> create(int dims, int maxNodeSize, 
-			double[] min, double[] max) {
+
+	/**
+	 * @param dims Number of dimensions per coordinate, usually 2 or 3
+	 * @param maxNodeSize Maximum node capacity before a split occurs. Default is 10.
+	 * @param min Estimated global minimum
+	 * @param max Estimated global minimum
+	 * @return New quadtree
+	 * @param <T> Value type
+	 * @deprecated Please use {@link #create(double[], double[], boolean, int)}
+	 */
+	@Deprecated
+	public static <T> QuadTreeRKD0<T> create(int dims, int maxNodeSize, double[] min, double[] max) {
+		return create(min, max, false, maxNodeSize);
+	}
+
+	/**
+	 * @param min Estimated global minimum
+	 * @param max Estimated global minimum
+	 * @param align Whether min and max should be aligned to powers of two. Aligning considerably
+	 *              reduces risk of precision problems. Recommended: "true".
+	 * @param maxNodeSize Maximum node capacity before a split occurs. Default is 10.
+	 * @return New quadtree
+	 * @param <T> Value type
+	 */
+	public static <T> QuadTreeRKD0<T> create(double[] min, double[] max, boolean align, int maxNodeSize) {
 		double radius = 0;
-		double[] center = new double[dims];
-		for (int i = 0; i < dims; i++) {
+		double[] center = new double[min.length];
+		for (int i = 0; i < center.length; i++) {
 			center[i] = (max[i]+min[i])/2.0;
 			if (max[i]-min[i]>radius) {
 				radius = max[i]-min[i];
 			}
 		}
-		return create(dims, maxNodeSize, center, radius);
+		return create(center, radius, align, maxNodeSize);
 	}
-	
-	public static <T> QuadTreeRKD0<T> create(int dims, int maxNodeSize, 
-			double[] center, double radius) {
-		QuadTreeRKD0<T> t = new QuadTreeRKD0<>(dims, maxNodeSize);
+
+	/**
+	 * WARNING: Unaligned center and radius can cause precision problems.
+	 * @param dims dimensions, usually 2 or 3
+	 * @param maxNodeSize maximum entries per node, default is 10
+	 * @param center center of initial root node
+	 * @param radius radius of initial root node
+	 * @return New quadtree
+	 * @param <T> Value type
+	 * @deprecated Please use {@link #create(double[], double, boolean, int)}
+	 */
+	@Deprecated
+	public static <T> QuadTreeRKD0<T> create(int dims, int maxNodeSize, double[] center, double radius) {
+		return create(center, radius, false, maxNodeSize);
+	}
+
+	/**
+	 * Note: This will align center and radius to a power of two before creating a tree.
+	 * @param center center of initial root node
+	 * @param radius radius of initial root node
+	 * @param maxNodeSize maximum entries per node, default is 10
+	 * @param align Whether center and radius should be aligned to powers of two. Aligning considerably
+	 *              reduces risk of precision problems. Recommended: "true".
+	 * @return New quadtree
+	 * @param <T> Value type
+	 */
+	public static <T> QuadTreeRKD0<T> create(double[] center, double radius, boolean align, int maxNodeSize) {
+		QuadTreeRKD0<T> t = new QuadTreeRKD0<>(center.length, maxNodeSize);
 		if (radius <= 0) {
 			throw new IllegalArgumentException("Radius must be > 0 but was " + radius);
+		}
+		if (align) {
+			center = MathTools.floorPowerOfTwoCopy(center);
+			radius = MathTools.ceilPowerOfTwo(radius);
 		}
 		t.root = new QRNode<>(Arrays.copyOf(center, center.length), radius);
 		return t;

--- a/src/main/java/org/tinspin/index/util/MathTools.java
+++ b/src/main/java/org/tinspin/index/util/MathTools.java
@@ -33,6 +33,20 @@ public class MathTools {
     }
 
     /**
+     * Calculates the {@link #ceilPowerOfTwo(double)} of an array.
+     * @param d input vector
+     * @return copied vector with next power of two above or equal to 'input'
+     * @see #floorPowerOfTwo(double)
+     */
+    public static double[] ceilPowerOfTwoCopy(double[] d) {
+        double[] d2 = new double[d.length];
+        for (int i = 0; i < d.length; i++) {
+            d2[i] = ceilPowerOfTwo(d[i]);
+        }
+        return d2;
+    }
+
+    /**
      * Similar to Math.floor() with the floor being the next lower power of 2.
      * The resulting number can repeatedly and (almost) always be divided by two without loss of precision.
      * We calculate the "floor" by setting the "fraction" of the bit representation to 0.


### PR DESCRIPTION
Use the power-of-2 approach (Issue #42 and PR #43) for all quadtree type indexes.
This approach immensely reduces precision errors.