### PR TITLE
Set valid version range for phtree

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 		<dependency>
 			<groupId>ch.ethz.globis.phtree</groupId>
 			<artifactId>phtree</artifactId>
-			<version>[2.8,)</version>
+			<version>[2.8.0,)</version>
 		</dependency>
 		<dependency>
 			<groupId>org.tinspin</groupId>


### PR DESCRIPTION
The version range 2.8 for phtree causes build failures in some maven settings since 2.8 is not att valid phtree version. Changing it to version 2.8.0 fixes those failures.